### PR TITLE
Fix bulkSet

### DIFF
--- a/src/indexeddb/worker.js
+++ b/src/indexeddb/worker.js
@@ -288,7 +288,7 @@ class Transaction {
     this.prevReads = null;
 
     for (let item of items) {
-      this.store.put(item.value, item.key);
+      await this.set(item);
     }
   }
 }

--- a/src/indexeddb/worker.js
+++ b/src/indexeddb/worker.js
@@ -287,9 +287,7 @@ class Transaction {
   async bulkSet(items) {
     this.prevReads = null;
 
-    for (let item of items) {
-      await this.set(item);
-    }
+    await Promise.all(items.map((item) => this.set(item)));
   }
 }
 


### PR DESCRIPTION
~I think it may potentially fix https://github.com/jlongster/absurd-sql/issues/30~

After that fix, the writing performance become slower. But we should await before all the writes finish to finish the transaction. Otherwise, the next read IDB (when you want to execute SELECT for example) will need to await when previous INSERT will finish, which is not fair for the SELECT query. And, it seems the benchmarks are wrong at the article (but not so much! The write performance is still amazing).

Also, I don't see any performance penalty of `Promise.all` usage — the new IDB transactions are not spawning, the overall performance at the first glance is the same.